### PR TITLE
Fix Docker multi-platform build SEGFAULT issue (#17)

### DIFF
--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -53,6 +53,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: ./Server

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+# Use build platform for SDK operations to avoid QEMU issues
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG TARGETARCH
 WORKDIR /src
 
 # Copy project files
@@ -9,19 +11,20 @@ COPY ["Brewery.Server.Logic.RaspberryPi/Brewery.Server.Logic.RaspberryPi.csproj"
 COPY ["Brewery.Server.Logic/Brewery.Server.Logic.csproj", "Brewery.Server.Logic/"]
 COPY ["Brewery.Server/Brewery.Server.csproj", "Brewery.Server/"]
 
-# Restore dependencies
-RUN dotnet restore "Brewery.Server/Brewery.Server.csproj"
+# Restore dependencies for target architecture
+RUN dotnet restore "Brewery.Server/Brewery.Server.csproj" -a $TARGETARCH
 
 # Copy source code
 COPY . .
 
-# Build
+# Build for target architecture
 WORKDIR "/src/Brewery.Server"
-RUN dotnet build "Brewery.Server.csproj" -c Release -o /app/build
+RUN dotnet build "Brewery.Server.csproj" -c Release -a $TARGETARCH -o /app/build --no-restore
 
 # Publish
 FROM build AS publish
-RUN dotnet publish "Brewery.Server.csproj" -c Release -o /app/publish /p:UseAppHost=false
+ARG TARGETARCH
+RUN dotnet publish "Brewery.Server.csproj" -c Release -a $TARGETARCH -o /app/publish --no-restore /p:UseAppHost=false
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final


### PR DESCRIPTION
This commit resolves the exit code 139 (SEGFAULT) error during `dotnet restore` when building Docker images for ARM platforms using QEMU emulation.

Changes:
- Updated Dockerfile to use --platform=$BUILDPLATFORM for SDK stage
- Added TARGETARCH argument to properly cross-compile for target platforms
- Added architecture flags (-a $TARGETARCH) to restore, build, and publish commands
- Fixed missing step ID in server-docker.yml workflow for attestation reference

The build now runs restore/build operations natively on the host platform (amd64) and cross-compiles for the target architectures (amd64, arm64, arm/v7), avoiding QEMU emulation issues with the .NET SDK.

Fixes #17