### PR TITLE
Fix server-docker workflow attestation issues

### DIFF
--- a/.github/workflows/server-docker.yml
+++ b/.github/workflows/server-docker.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
     - name: Checkout code
@@ -53,6 +55,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: ./Server
@@ -66,6 +69,7 @@ jobs:
 
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v1
+      if: github.event_name != 'pull_request'
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
- Add id: build to build step so digest can be referenced
- Add required permissions: id-token and attestations write
- Skip attestation on pull requests (only run on pushes/tags)
- Fix reference to steps.build.outputs.digest

This resolves the "Failed to get ID token" error.