### PR TITLE
Fix npm peer dependency conflict in postCreateCommand

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -126,6 +126,17 @@ If dependencies are missing, run the setup script manually:
 bash .devcontainer/setup.sh
 ```
 
+### Peer Dependency Warnings
+
+The project uses `angular-in-memory-web-api` which doesn't have a version compatible with Angular 19. The setup script uses `--legacy-peer-deps` to work around this. This is safe for development purposes.
+
+If you need to manually install frontend dependencies:
+
+```bash
+cd WebApp
+npm install --legacy-peer-deps
+```
+
 ### Port conflicts
 
 If ports 8800 or 4200 are already in use, you can change them:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -28,7 +28,8 @@ fi
 
 # Install frontend dependencies
 echo "📦 Installing frontend dependencies..."
-if cd WebApp && npm install && cd ..; then
+echo "ℹ️  Using --legacy-peer-deps due to angular-in-memory-web-api compatibility"
+if cd WebApp && npm install --legacy-peer-deps && cd ..; then
   echo "✅ Frontend dependencies installed"
 else
   echo "❌ Failed to install frontend dependencies"


### PR DESCRIPTION
The postCreateCommand was failing due to a peer dependency conflict:
- WebApp uses Angular 19
- angular-in-memory-web-api@0.18.0 requires Angular 18
- angular-in-memory-web-api@0.19.0 requires Angular 20
- No version exists for Angular 19

Solution: Use --legacy-peer-deps flag during npm install

Changes:
- Updated setup.sh to use npm install --legacy-peer-deps
- Added troubleshooting section to README.md explaining the issue
- Added informative message during setup about why we use this flag

This allows the Codespace to fully initialize without errors.