### PR TITLE
Fix build errors and warnings

### DIFF
--- a/Server/Brewery.Server.Logic.RaspberryPiMock/Api/GpioModule.cs
+++ b/Server/Brewery.Server.Logic.RaspberryPiMock/Api/GpioModule.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System;
 using System.Collections.Generic;
 
-namespace Brewery.Server.Logic.RaspberryPi.Api
+namespace Brewery.Server.Logic.RaspberryPiMock.Api
 {
     public class GpioModule : IGpioModule
     {

--- a/Server/Brewery.Server.Logic.RaspberryPiMock/Api/TemperatureModule.cs
+++ b/Server/Brewery.Server.Logic.RaspberryPiMock/Api/TemperatureModule.cs
@@ -1,7 +1,7 @@
 ﻿using Brewery.Server.Core.Api;
 using System.Diagnostics;
 
-namespace Brewery.Server.Logic.RaspberryPi.Api
+namespace Brewery.Server.Logic.RaspberryPiMock.Api
 {
     public class TemperatureModule : ITemperatureModule
     {

--- a/Server/Brewery.Server.Logic/Brewery.Server.Logic.csproj
+++ b/Server/Brewery.Server.Logic/Brewery.Server.Logic.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fix namespace in RaspberryPiMock project files (GpioModule.cs and TemperatureModule.cs) Changed from Brewery.Server.Logic.RaspberryPi.Api to Brewery.Server.Logic.RaspberryPiMock.Api This resolves the compilation error where RaspberryPiMock namespace could not be found

- Replace PackageReference with FrameworkReference for Microsoft.AspNetCore.App This fixes NETSDK1080 warning about unnecessary PackageReference in .NET 8.0 projects

Fixes #31