### PR TITLE
Fix worker class accessibility for ServerMock

### DIFF
--- a/Server/Brewery.Server.Logic/Service/BoilingPlate1Worker.cs
+++ b/Server/Brewery.Server.Logic/Service/BoilingPlate1Worker.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Brewery.Server.Logic.Service
 {
-    class BoilingPlate1Worker : Core.Service.IBoilingPlate1Worker
+    public class BoilingPlate1Worker : Core.Service.IBoilingPlate1Worker
     {
         enum ServiceStatus
         {

--- a/Server/Brewery.Server.Logic/Service/BoilingPlate2Worker.cs
+++ b/Server/Brewery.Server.Logic/Service/BoilingPlate2Worker.cs
@@ -6,7 +6,7 @@ using Brewery.Server.Core.Models;
 
 namespace Brewery.Server.Logic.Service
 {
-    class BoilingPlate2Worker : Core.Service.IBoilingPlate2Worker
+    public class BoilingPlate2Worker : Core.Service.IBoilingPlate2Worker
     {
         private readonly IGpioModule _gpioModule;
         private readonly ITemperatureModule _temperatureModule;


### PR DESCRIPTION
- Make BoilingPlate1Worker and BoilingPlate2Worker public Both classes were internal by default, preventing access from ServerMock project Changed from 'class' to 'public class' to resolve CS0122 accessibility errors

Part of #31