### PR TITLE
Add VSCode debug configurations for Server, ServerMock, and WebApp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,72 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "WebApp (Chrome)",
+            "type": "chrome",
+            "request": "launch",
+            "preLaunchTask": "npm: start - WebApp",
+            "url": "http://localhost:4200",
+            "webRoot": "${workspaceFolder}/WebApp",
+            "sourceMapPathOverrides": {
+                "webpack:/*": "${webRoot}/*",
+                "/./*": "${webRoot}/*",
+                "/src/*": "${webRoot}/*",
+                "/*": "*",
+                "/./~/*": "${webRoot}/node_modules/*"
+            }
+        },
+        {
+            "name": "Server (.NET)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Server/Brewery.Server/bin/Debug/net8.0/Brewery.Server.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Server/Brewery.Server",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
+            "name": "ServerMock (.NET)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Server/Brewery.ServerMock/bin/Debug/net8.0/Brewery.ServerMock.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Server/Brewery.ServerMock",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
+            "name": "Attach to Server (.NET)",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        },
+        {
+            "name": "Attach to ServerMock (.NET)",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Full Stack (ServerMock + WebApp)",
+            "configurations": [
+                "ServerMock (.NET)",
+                "WebApp (Chrome)"
+            ],
+            "stopAll": true
+        },
+        {
+            "name": "Full Stack (Server + WebApp)",
+            "configurations": [
+                "Server (.NET)",
+                "WebApp (Chrome)"
+            ],
+            "stopAll": true
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,71 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Server/Brewery.Server.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build-server",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Server/Brewery.Server/Brewery.Server.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-servermock",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Server/Brewery.ServerMock/Brewery.ServerMock.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "type": "npm",
+            "script": "start",
+            "path": "WebApp/",
+            "label": "npm: start - WebApp",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "typescript",
+                "source": "ts",
+                "applyTo": "closedDocuments",
+                "fileLocation": [
+                    "relative",
+                    "${cwd}"
+                ],
+                "pattern": "$tsc",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": {
+                        "regexp": "(.*?)"
+                    },
+                    "endsPattern": {
+                        "regexp": "Compiled |Failed to compile."
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Created launch.json with debugging configurations for:
- WebApp (Angular app debugging in Chrome)
- Server (.NET 8.0 console app)
- ServerMock (.NET 8.0 console app)
- Attach configurations for running processes
- Compound configurations for full-stack debugging

Also added tasks.json to support build and start tasks.