### PR TITLE
Fix WebApp debug configuration for Angular 19

### DIFF
--- a/WebApp/angular.json
+++ b/WebApp/angular.json
@@ -61,18 +61,18 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "brewery:build"
+            "buildTarget": "brewery:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "brewery:build:production"
+              "buildTarget": "brewery:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "brewery:build"
+            "buildTarget": "brewery:build"
           }
         },
         "test": {


### PR DESCRIPTION
Updated angular.json to use 'buildTarget' instead of deprecated 'browserTarget' property in serve and extract-i18n configurations. This resolves the schema validation error when debugging the WebApp in VSCode.

Fixes #39