### PR TITLE
Configure WebApp to use environment-based API URL

### DIFF
--- a/WebApp/src/app/settings.ts
+++ b/WebApp/src/app/settings.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
+import { environment } from '../environments/environment';
 
 @Injectable({
     providedIn: 'root',
   })
 export class Settings {
-    // ApiUrl = 'http://192.168.178.35:8800/api/';
-    ApiUrl = 'http://minwinpc:8800/api/';
+    ApiUrl = environment.apiUrl;
     httpOptions = {
         headers: new HttpHeaders({ 'Content-Type': 'application/json' })
       };

--- a/WebApp/src/environments/environment.prod.ts
+++ b/WebApp/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: '/api/'
 };

--- a/WebApp/src/environments/environment.ts
+++ b/WebApp/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:8800/api/'
 };
 
 /*


### PR DESCRIPTION
Fixes #41

Replaced hardcoded machine-specific URI (http://minwinpc:8800/api/) with environment-based configuration to support flexible development setups.

Changes:
- Updated Settings service to import and use environment.apiUrl
- Added apiUrl to environment.ts with localhost:8800 for development
- Added apiUrl to environment.prod.ts with relative path for production

This enables the WebApp to work correctly in VS Code debugging, dev containers, and other development environments without manual configuration changes.