### PR TITLE
Fix API routing by converting absolute paths to relative paths in ser…

### DIFF
--- a/Server/Brewery.ServiceAdapter/BoilingPlate1Service.cs
+++ b/Server/Brewery.ServiceAdapter/BoilingPlate1Service.cs
@@ -14,13 +14,13 @@ namespace Brewery.ServiceAdapter
 
         public async Task<double> GetCurrenTemperature()
         {
-            var t = await _requestHelper.SendRequest<double>("/boilingPlate1/getCurrentTemperature", MethodTypes.GET);
+            var t = await _requestHelper.SendRequest<double>("boilingPlate1/getCurrentTemperature", MethodTypes.GET);
             return t;
         }
 
         public async Task<bool> GetPowerStatus()
         {
-            var t = await _requestHelper.SendRequest<bool>("/boilingPlate1/powerStatus", MethodTypes.GET);
+            var t = await _requestHelper.SendRequest<bool>("boilingPlate1/powerStatus", MethodTypes.GET);
             return t;
         }
     }

--- a/Server/Brewery.ServiceAdapter/BoilingPlate2Service.cs
+++ b/Server/Brewery.ServiceAdapter/BoilingPlate2Service.cs
@@ -14,24 +14,24 @@ namespace Brewery.ServiceAdapter
 
         public async Task<double> GetCurrenTemperature()
         {
-            var t = await _requestHelper.SendRequest<double>("/boilingPlate2/getCurrentTemperature", MethodTypes.GET);
+            var t = await _requestHelper.SendRequest<double>("boilingPlate2/getCurrentTemperature", MethodTypes.GET);
             return t;
         }
 
         public async Task<bool> GetPowerStatus()
         {
-            var t = await _requestHelper.SendRequest<bool>("/boilingPlate2/powerStatus", MethodTypes.GET);
+            var t = await _requestHelper.SendRequest<bool>("boilingPlate2/powerStatus", MethodTypes.GET);
             return t;
         }
-        
+
         public async Task PowerOff()
         {
-            await _requestHelper.SendRequest<bool>($"/boilingPlate2/power/{false}", MethodTypes.PUT);
+            await _requestHelper.SendRequest<bool>($"boilingPlate2/power/{false}", MethodTypes.PUT);
         }
 
         public async Task PowerOn()
         {
-            await _requestHelper.SendRequest<bool>($"/boilingPlate2/power/{true}", MethodTypes.PUT);
+            await _requestHelper.SendRequest<bool>($"boilingPlate2/power/{true}", MethodTypes.PUT);
         }
     }
 }

--- a/Server/Brewery.ServiceAdapter/MixerService.cs
+++ b/Server/Brewery.ServiceAdapter/MixerService.cs
@@ -14,7 +14,7 @@ namespace Brewery.ServiceAdapter
 
         public async Task Power(bool on)
         {
-            await _requestHelper.SendRequest($"/mixer/power/{on}", MethodTypes.PUT);
+            await _requestHelper.SendRequest($"mixer/power/{on}", MethodTypes.PUT);
         }
     }
 }

--- a/Server/Brewery.ServiceAdapter/PiezoService.cs
+++ b/Server/Brewery.ServiceAdapter/PiezoService.cs
@@ -13,7 +13,7 @@ namespace Brewery.ServiceAdapter
 
         public async Task Power(bool on)
         {
-            await _requestHelper.SendRequest($"/piezo/power/{on}", MethodTypes.PUT);
+            await _requestHelper.SendRequest($"piezo/power/{on}", MethodTypes.PUT);
         }
     }
 }


### PR DESCRIPTION
…vice adapters

The server was returning 404 errors because service adapters were using absolute paths (e.g., "/piezo/power/False") with HttpClient's BaseAddress. When HttpClient sees an absolute path, it replaces the entire path portion of the BaseAddress instead of appending to it.

Fixed by converting all service adapter request paths from absolute to relative:
- PiezoService: /piezo/power/{on} → piezo/power/{on}
- MixerService: /mixer/power/{on} → mixer/power/{on}
- BoilingPlate1Service: /boilingPlate1/* → boilingPlate1/*
- BoilingPlate2Service: /boilingPlate2/* → boilingPlate2/*

This ensures requests properly combine with the BaseAddress (http://localhost:8800/api/) to produce the correct URLs like http://localhost:8800/api/piezo/power/False.

Fixes #48