### PR TITLE
Fix mockserver 404 error on root path by adding UseDefaultFiles middl…

### DIFF
--- a/Server/Brewery.Server.Logic/Server.cs
+++ b/Server/Brewery.Server.Logic/Server.cs
@@ -44,6 +44,15 @@ namespace Brewery.Server.Logic
 
             // Configure middleware
             app.UseCors();
+
+            // Enable default files (index.html) for root path
+            app.UseDefaultFiles(new DefaultFilesOptions
+            {
+                FileProvider = new PhysicalFileProvider(
+                    Path.Combine(Directory.GetCurrentDirectory(), "Web")),
+                RequestPath = ""
+            });
+
             app.UseStaticFiles(new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(


### PR DESCRIPTION
…eware

The mockserver was returning 404 when accessing the root path (/) because it lacked the DefaultFiles middleware to automatically serve index.html. This change adds UseDefaultFiles before UseStaticFiles to enable automatic serving of index.html when users navigate to the root URL.

Fixes #[issue-number]