### PR TITLE
Fix Angular double slash in API URLs by removing trailing slash

### DIFF
--- a/WebApp/src/environments/environment.prod.ts
+++ b/WebApp/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: '/api/'
+  apiUrl: '/api'
 };

--- a/WebApp/src/environments/environment.ts
+++ b/WebApp/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8800/api/'
+  apiUrl: 'http://localhost:8800/api'
 };
 
 /*


### PR DESCRIPTION
Removed trailing slash from apiUrl in both environment files to prevent double slashes in constructed URLs. All Angular services use paths with leading slashes (e.g., '/mashSteps'), so the base URL should not have a trailing slash.

Before: http://localhost:8800/api/ + /mashSteps = api//mashSteps (404)
After:  http://localhost:8800/api + /mashSteps = api/mashSteps (works)

Affected environment files:
- environment.ts: 'http://localhost:8800/api/' → 'http://localhost:8800/api'
- environment.prod.ts: '/api/' → '/api'