### PR TITLE
Fix ServerMock timeout issue in VSCode Codespace debug sessions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,8 +27,10 @@
             "stopAtEntry": false,
             "console": "internalConsole",
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            }
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_SHUTDOWNTIMEOUTSECONDS": "3600"
+            },
+            "requireExactSource": false
         },
         {
             "name": "ServerMock (.NET)",
@@ -41,8 +43,10 @@
             "stopAtEntry": false,
             "console": "internalConsole",
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            }
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_SHUTDOWNTIMEOUTSECONDS": "3600"
+            },
+            "requireExactSource": false
         },
         {
             "name": "Attach to Server (.NET)",

--- a/Server/Brewery.Server.Logic/Server.cs
+++ b/Server/Brewery.Server.Logic/Server.cs
@@ -68,7 +68,14 @@ namespace Brewery.Server.Logic
 
             // Start web server
             Console.WriteLine($"Starting web server on http://0.0.0.0:{port}");
-            await app.RunAsync($"http://0.0.0.0:{port}");
+
+            // Use StartAsync instead of RunAsync to start the server without blocking
+            await app.StartAsync($"http://0.0.0.0:{port}");
+            Console.WriteLine($"Web server started and listening on http://0.0.0.0:{port}");
+
+            // Wait for the application lifetime to end (keeps server running indefinitely)
+            await app.WaitForShutdownAsync();
+            Console.WriteLine("Web server is shutting down...");
         }
 
         private async Task StartWorkerAsync(Func<Task> workerTask, int intervall)


### PR DESCRIPTION
When debugging with F5 (ServerMock + WebApp) in Codespaces, the ServerMock process was being terminated after some time while ng server continued running.

Changes:
1. Server.cs: Use StartAsync() + WaitForShutdownAsync() pattern instead of RunAsync()
   - This ensures the server waits properly for shutdown signals
   - Prevents premature termination in debug environments

2. launch.json: Add timeout and debug configurations
   - Set DOTNET_SHUTDOWNTIMEOUTSECONDS=3600 to prevent early shutdown
   - Add requireExactSource=false to prevent debugger disconnects
   - Applied to both Server and ServerMock configurations

This follows the standard ASP.NET Core hosting pattern for long-running services.