### PR TITLE
Change backend default port from 8801 to 8800

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -194,7 +194,7 @@ If ports 8800 or 4200 are already in use, you can change them:
 ```bash
 # Backend with custom port
 cd Server/Brewery.ServerMock
-dotnet run --urls "http://localhost:8801"
+dotnet run -- 9000
 
 # Frontend with custom port
 cd WebApp

--- a/Server/Brewery.ServerMock/Program.cs
+++ b/Server/Brewery.ServerMock/Program.cs
@@ -14,8 +14,8 @@ namespace Brewery.ServerMock
 
             try
             {
-                // Determine port: command-line args > environment variable > default (8801)
-                int port = GetPort(args, defaultPort: 8801);
+                // Determine port: command-line args > environment variable > default (8800)
+                int port = GetPort(args, defaultPort: 8800);
 
                 // Setup IoC container with MOCK implementations
                 BootstrapperMock.SetUpServerLogicMock();


### PR DESCRIPTION
- Update Program.cs to use port 8800 as default
- Align with backend quick-command configuration
- Update README.md port conflict example