### PR TITLE
Make API URL dynamic to support different hosting environments

### DIFF
--- a/WebApp/src/environments/environment.prod.ts
+++ b/WebApp/src/environments/environment.prod.ts
@@ -1,4 +1,46 @@
+/**
+ * Dynamically determines the API URL based on the current window location.
+ * This allows the app to work correctly in different environments:
+ * - localhost (port 8800 with relative path)
+ * - GitHub Codespaces (dynamic URLs with port forwarding)
+ * - Production deployments (relative URLs)
+ */
+function getApiUrl(): string {
+  const { protocol, hostname, port } = window.location;
+
+  // If running on localhost
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    // In production build, we typically serve from the same port as backend
+    return '/api';
+  }
+
+  // For GitHub Codespaces URLs (pattern: xxx-YYYY.app.github.dev)
+  if (hostname.includes('.app.github.dev')) {
+    // Extract and replace port number in hostname
+    const portMatch = hostname.match(/-(\d+)\.app\.github\.dev$/);
+    if (portMatch) {
+      const currentPort = portMatch[1];
+      // If we're on a different port (like 4200), change to 8800
+      if (currentPort !== '8800') {
+        const backendHostname = hostname.replace(/-\d+\.app\.github\.dev$/, '-8800.app.github.dev');
+        return `${protocol}//${backendHostname}/api`;
+      }
+      // Already on port 8800, use relative path
+      return '/api';
+    }
+  }
+
+  // For other remote hosts with explicit port numbers
+  if (port && port !== '8800') {
+    // We're on a different port, explicitly use port 8800
+    return `${protocol}//${hostname}:8800/api`;
+  }
+
+  // Default: use relative path (works when frontend and backend share the same origin)
+  return '/api';
+}
+
 export const environment = {
   production: true,
-  apiUrl: '/api'
+  apiUrl: getApiUrl()
 };

--- a/WebApp/src/environments/environment.ts
+++ b/WebApp/src/environments/environment.ts
@@ -2,9 +2,55 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+/**
+ * Dynamically determines the API URL based on the current window location.
+ * This allows the app to work correctly in different environments:
+ * - localhost development (port 4200 -> port 8800)
+ * - GitHub Codespaces (dynamic URLs with port forwarding)
+ * - Production (relative URLs)
+ */
+function getApiUrl(): string {
+  const { protocol, hostname, port } = window.location;
+
+  // If running on localhost
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    // If frontend is on port 4200 (ng serve), backend is on 8800
+    if (port === '4200') {
+      return 'http://localhost:8800/api';
+    }
+    // If frontend is on port 8800 or no specific port, use relative path
+    return '/api';
+  }
+
+  // For GitHub Codespaces URLs (pattern: xxx-YYYY.app.github.dev)
+  if (hostname.includes('.app.github.dev')) {
+    // Extract and replace port number in hostname
+    const portMatch = hostname.match(/-(\d+)\.app\.github\.dev$/);
+    if (portMatch) {
+      const currentPort = portMatch[1];
+      // If we're on a different port (like 4200), change to 8800
+      if (currentPort !== '8800') {
+        const backendHostname = hostname.replace(/-\d+\.app\.github\.dev$/, '-8800.app.github.dev');
+        return `${protocol}//${backendHostname}/api`;
+      }
+      // Already on port 8800, use relative path
+      return '/api';
+    }
+  }
+
+  // For other remote hosts with explicit port numbers
+  if (port && port !== '8800') {
+    // We're on a different port, explicitly use port 8800
+    return `${protocol}//${hostname}:8800/api`;
+  }
+
+  // Default: use relative path (works when frontend and backend share the same origin)
+  return '/api';
+}
+
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8800/api'
+  apiUrl: getApiUrl()
 };
 
 /*


### PR DESCRIPTION
Updated both development and production environment files to dynamically determine the API URL based on the current window location. This enables the webapp to work correctly in various scenarios:

- Local development: localhost:4200 -> localhost:8800/api
- GitHub Codespaces: automatically uses the correct forwarded URL
- Remote deployments: intelligently handles custom ports and domains
- Production builds: uses relative URLs when served from same origin

The dynamic URL resolution handles:
- GitHub Codespaces port-forwarding format (xxx-YYYY.app.github.dev)
- Localhost with different ports (4200 for dev, 8800 for prod)
- Remote hosts with explicit port numbers
- Fallback to relative URLs for same-origin deployments

Fixes the issue where hardcoded localhost:8800 prevented the app from working in containerized or remote environments.