### PR TITLE
Fix GitHub Issue #68

### DIFF
--- a/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
+++ b/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
@@ -2,7 +2,7 @@
   Steuerung: <mat-slide-toggle [(ngModel)]="Power" (change)="onPowerToggleChange($event)"></mat-slide-toggle>
 </p>
 <p>
-  Temperatur soll: <mat-slider (input)="onTemperatureSliderChange($event)" thumbLabel="true" [(ngModel)]="Temperature"></mat-slider> {{Temperature}} &deg;C
+  Temperatur soll: <mat-slider (input)="onTemperatureSliderChange($event)" (change)="onTemperatureSliderChangeEnd($event)" thumbLabel="true" [(ngModel)]="Temperature"></mat-slider> {{Temperature}} &deg;C
 </p>
 <p>
   Temperatur aktuell: {{TemperatureCurrent}} &deg;C

--- a/WebApp/src/app/boiling-plate2/boiling-plate2.component.ts
+++ b/WebApp/src/app/boiling-plate2/boiling-plate2.component.ts
@@ -18,6 +18,7 @@ export class BoilingPlate2Component implements OnInit, OnDestroy {
   powerStatusSubscription: any;
   currentTemperatureSubscription: any;
   temperatureSubscription: any;
+  isUserChangingTemperature: boolean = false;
 
   constructor(private boilingPlate2Service: BoilingPlate2Service, private settings: Settings) { }
 
@@ -28,7 +29,11 @@ export class BoilingPlate2Component implements OnInit, OnDestroy {
         startWith(0),
         switchMap(() => this.boilingPlate2Service.getTemperature())
       )
-      .subscribe(t => this.Temperature = Math.round(t));
+      .subscribe(t => {
+        if (!this.isUserChangingTemperature) {
+          this.Temperature = Math.round(t);
+        }
+      });
 
     // this.getCurrentTemperature();
     this.currentTemperatureSubscription = interval(this.settings.pollingInterval)
@@ -70,6 +75,13 @@ export class BoilingPlate2Component implements OnInit, OnDestroy {
   }
 
   onTemperatureSliderChange(event) {
-    this.boilingPlate2Service.setTemperature(event.value).subscribe();
+    this.isUserChangingTemperature = true;
+    this.Temperature = event.value;
+  }
+
+  onTemperatureSliderChangeEnd(event) {
+    this.boilingPlate2Service.setTemperature(event.value).subscribe(() => {
+      this.isUserChangingTemperature = false;
+    });
   }
 }


### PR DESCRIPTION
The temperature slider was not usable with the mouse because the polling mechanism continuously overwrote user input. This fix introduces a flag to track when the user is actively changing the temperature value, preventing the polling subscription from interfering with user input.

Changes:
- Added isUserChangingTemperature flag to track slider interaction state
- Modified temperature polling to respect the flag and only update when not in use
- Split slider events: (input) for live updates and (change) for finalizing
- Only send value to backend when user finishes adjusting the slider

Fixes #68