### PR TITLE
Fix GitHub issue #67 in Brewery

### DIFF
--- a/WebApp/src/app/mash-steps/mash-steps.component.ts
+++ b/WebApp/src/app/mash-steps/mash-steps.component.ts
@@ -15,7 +15,7 @@ export class MashStepsComponent implements OnInit {
   private api;
   private columnApi;
 
-  mashSteps: MashStep[];
+  mashSteps: MashStep[] = [];
   trueFalseValues: string[] = ['true', 'false'];
   trueFalseCellEditorParams = { values: this.trueFalseValues };
 


### PR DESCRIPTION
Initialize mashSteps array to empty array instead of undefined. This fixes issue #67 where the ag-grid table in the mash-steps component (accessed via boiling plate settings) was not displaying properly due to undefined rowData binding.