### PR TITLE
Fix DirectoryNotFoundException by using AppContext.BaseDirectory

### DIFF
--- a/Server/Brewery.Server.Logic/Server.cs
+++ b/Server/Brewery.Server.Logic/Server.cs
@@ -52,14 +52,14 @@ namespace Brewery.Server.Logic
             app.UseDefaultFiles(new DefaultFilesOptions
             {
                 FileProvider = new PhysicalFileProvider(
-                    Path.Combine(Directory.GetCurrentDirectory(), "Web")),
+                    Path.Combine(AppContext.BaseDirectory, "Web")),
                 RequestPath = ""
             });
 
             app.UseStaticFiles(new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(
-                    Path.Combine(Directory.GetCurrentDirectory(), "Web")),
+                    Path.Combine(AppContext.BaseDirectory, "Web")),
                 RequestPath = ""
             });
 


### PR DESCRIPTION
The mock server was failing to start with a DirectoryNotFoundException because it was looking for the Web directory using Directory.GetCurrentDirectory(), which depends on the working directory from which the application is launched.

Changed to use AppContext.BaseDirectory instead, which points to the directory where the application executable is located. This is where the Web directory is copied during build (as configured in the .csproj files).

This fix ensures the server can find the Web directory regardless of the working directory from which it's launched.

Fixes #73