### PR TITLE
Fix devcontainer configuration for .NET 10 preview

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,13 @@
 {
   "name": "Brewery Development",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm",
+  "image": "mcr.microsoft.com/dotnet/sdk:10.0-preview",
 
   "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "vscode",
+      "userUid": "1000",
+      "userGid": "1000"
+    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"
     },


### PR DESCRIPTION
- Replace invalid image tag 'mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm' with valid .NET 10 preview SDK image 'mcr.microsoft.com/dotnet/sdk:10.0-preview'
- Add common-utils feature to create vscode user for proper devcontainer setup
- Resolves docker inspect failures during GitHub Codespaces initialization

Fixes #77