### PR TITLE
Fix devcontainer initialization issue with .NET 10 preview

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# Start with the official .NET 9.0 devcontainer image as base
+# This ensures all devcontainer tooling is properly configured
+FROM mcr.microsoft.com/devcontainers/dotnet:9.0
+
+# Install .NET 10 Preview SDK
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
+    && chmod +x dotnet-install.sh \
+    && ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet \
+    && rm dotnet-install.sh
+
+# Verify .NET 10 is installed
+RUN dotnet --list-sdks
+
+# Set environment variables for .NET
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH=$PATH:/usr/share/dotnet

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -6,7 +6,7 @@ This directory contains the configuration for GitHub Codespaces, allowing you to
 
 The devcontainer provides:
 
-- **.NET 8 SDK** - For backend development
+- **.NET 10 Preview SDK** - For backend development (with .NET 9 also available)
 - **Node.js 20** - For Angular frontend development
 - **Angular CLI** - Pre-installed globally
 - **Docker-in-Docker** - For building and testing containers

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Brewery Development",
-  "image": "mcr.microsoft.com/dotnet/sdk:10.0-preview",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
 
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {


### PR DESCRIPTION
The devcontainer was using the raw .NET SDK image (mcr.microsoft.com/dotnet/sdk:10.0-preview) instead of the official devcontainer image. Since there's no official devcontainer image for .NET 10 preview yet, this caused initialization failures in GitHub Codespaces.

Changes:
- Created custom Dockerfile that builds on official .NET 9 devcontainer image and adds .NET 10 preview SDK
- Updated devcontainer.json to use the custom Dockerfile instead of raw SDK image
- Updated README.md to reflect .NET 10 preview instead of .NET 8

This approach ensures all devcontainer tooling is properly configured while supporting .NET 10 development.

Fixes #79