### PR TITLE
Update .NET 10 references from Preview to GA

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # This ensures all devcontainer tooling is properly configured
 FROM mcr.microsoft.com/devcontainers/dotnet:9.0
 
-# Install .NET 10 Preview SDK
+# Install .NET 10 SDK (GA)
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
     && chmod +x dotnet-install.sh \
     && ./dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -6,7 +6,7 @@ This directory contains the configuration for GitHub Codespaces, allowing you to
 
 The devcontainer provides:
 
-- **.NET 10 Preview SDK** - For backend development (with .NET 9 also available)
+- **.NET 10 SDK** - For backend development (with .NET 9 also available)
 - **Node.js 20** - For Angular frontend development
 - **Angular CLI** - Pre-installed globally
 - **Docker-in-Docker** - For building and testing containers


### PR DESCRIPTION
- Updated .devcontainer/Dockerfile comment to reference .NET 10 SDK (GA)
- Updated .devcontainer/README.md to reference .NET 10 SDK instead of Preview SDK
- The dotnet-install.sh script already uses channel 10.0, which now points to the GA release

Fixes #82