### PR TITLE
Fix SignalR Hub namespace conflict

### DIFF
--- a/Server/Brewery.Server.Logic/Api/Hubs/BoilingPlate1Hub.cs
+++ b/Server/Brewery.Server.Logic/Api/Hubs/BoilingPlate1Hub.cs
@@ -1,0 +1,67 @@
+using Brewery.Core;
+using Brewery.Server.Core.Api;
+using Brewery.Server.Core.Service;
+using Microsoft.AspNetCore.SignalR;
+using System.Threading.Tasks;
+
+namespace Brewery.Server.Logic.Api.Hubs
+{
+    public class BoilingPlate1Hub : Microsoft.AspNetCore.SignalR.Hub
+    {
+        private readonly IBoilingPlate1Worker _boilingPlate1Worker;
+        private readonly IGpioModule _gpioModule;
+        private readonly ITemperatureModule _temperatureModule;
+
+        public BoilingPlate1Hub()
+        {
+            _gpioModule = IocContainer.GetInstance<IGpioModule>();
+            _temperatureModule = IocContainer.GetInstance<ITemperatureModule>();
+            _boilingPlate1Worker = IocContainer.GetInstance<IBoilingPlate1Worker>();
+        }
+
+        // Client can call these methods
+        public async Task StartMashProcess()
+        {
+            _boilingPlate1Worker.StartMashProcess();
+            await Clients.All.SendAsync("MashProcessStarted");
+        }
+
+        public async Task StopMashProcess()
+        {
+            _boilingPlate1Worker.StopMashProcess();
+            await Clients.All.SendAsync("MashProcessStopped");
+        }
+
+        public async Task AcknowledgeMessage()
+        {
+            _boilingPlate1Worker.AcknowledgeMessage();
+            await Clients.All.SendAsync("MessageAcknowledged");
+        }
+
+        public async Task<bool> GetPowerStatus()
+        {
+            return await Task.FromResult(_boilingPlate1Worker.GetPowerStatus());
+        }
+
+        public async Task<double> GetCurrentTemperature()
+        {
+            return await Task.FromResult(_temperatureModule.GetCurrenTemperature(Settings.TemperatureSensor1OneWireAddress));
+        }
+
+        // Server calls these methods to push updates to clients
+        public static async Task BroadcastPowerStatus(IHubContext<BoilingPlate1Hub> hubContext, bool powerStatus)
+        {
+            await hubContext.Clients.All.SendAsync("PowerStatusUpdated", powerStatus);
+        }
+
+        public static async Task BroadcastCurrentTemperature(IHubContext<BoilingPlate1Hub> hubContext, double temperature)
+        {
+            await hubContext.Clients.All.SendAsync("CurrentTemperatureUpdated", temperature);
+        }
+
+        public static async Task BroadcastCurrentStep(IHubContext<BoilingPlate1Hub> hubContext, string step, int estimatedTime)
+        {
+            await hubContext.Clients.All.SendAsync("CurrentStepUpdated", new { Step = step, EstimatedTime = estimatedTime });
+        }
+    }
+}

--- a/Server/Brewery.Server.Logic/Api/Hubs/BoilingPlate2Hub.cs
+++ b/Server/Brewery.Server.Logic/Api/Hubs/BoilingPlate2Hub.cs
@@ -1,0 +1,66 @@
+using Brewery.Core;
+using Brewery.Server.Core.Api;
+using Brewery.Server.Core.Models;
+using Microsoft.AspNetCore.SignalR;
+using System.Threading.Tasks;
+
+namespace Brewery.Server.Logic.Api.Hubs
+{
+    public class BoilingPlate2Hub : Microsoft.AspNetCore.SignalR.Hub
+    {
+        private readonly IGpioModule _gpioModule;
+        private readonly ITemperatureModule _temperatureModule;
+        private readonly BoilingPlate2Model _boilingPlate2Model;
+
+        public BoilingPlate2Hub()
+        {
+            _gpioModule = IocContainer.GetInstance<IGpioModule>();
+            _temperatureModule = IocContainer.GetInstance<ITemperatureModule>();
+            _boilingPlate2Model = IocContainer.GetInstance<BoilingPlate2Model>();
+        }
+
+        // Client can call these methods
+        public async Task<bool> GetPowerStatus()
+        {
+            return await Task.FromResult(_boilingPlate2Model.PowerStatus);
+        }
+
+        public async Task SetPower(bool on)
+        {
+            _boilingPlate2Model.PowerStatus = on;
+            await Clients.All.SendAsync("PowerStatusUpdated", on);
+        }
+
+        public async Task<double> GetCurrentTemperature()
+        {
+            return await Task.FromResult(_temperatureModule.GetCurrenTemperature(Settings.TemperatureSensor2OneWireAddress));
+        }
+
+        public async Task<double> GetTemperature()
+        {
+            return await Task.FromResult(_boilingPlate2Model.Temperature);
+        }
+
+        public async Task SetTemperature(double temperature)
+        {
+            _boilingPlate2Model.Temperature = temperature;
+            await Clients.All.SendAsync("TemperatureSetpointUpdated", temperature);
+        }
+
+        // Server calls these methods to push updates to clients
+        public static async Task BroadcastPowerStatus(IHubContext<BoilingPlate2Hub> hubContext, bool powerStatus)
+        {
+            await hubContext.Clients.All.SendAsync("PowerStatusUpdated", powerStatus);
+        }
+
+        public static async Task BroadcastCurrentTemperature(IHubContext<BoilingPlate2Hub> hubContext, double temperature)
+        {
+            await hubContext.Clients.All.SendAsync("CurrentTemperatureUpdated", temperature);
+        }
+
+        public static async Task BroadcastTemperatureSetpoint(IHubContext<BoilingPlate2Hub> hubContext, double temperature)
+        {
+            await hubContext.Clients.All.SendAsync("TemperatureSetpointUpdated", temperature);
+        }
+    }
+}

--- a/Server/Brewery.Server.Logic/Api/Hubs/HubContextProvider.cs
+++ b/Server/Brewery.Server.Logic/Api/Hubs/HubContextProvider.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace Brewery.Server.Logic.Api.Hubs
+{
+    public static class HubContextProvider
+    {
+        public static IHubContext<BoilingPlate1Hub> BoilingPlate1HubContext { get; set; }
+        public static IHubContext<BoilingPlate2Hub> BoilingPlate2HubContext { get; set; }
+        public static IHubContext<MashStepsHub> MashStepsHubContext { get; set; }
+    }
+}

--- a/Server/Brewery.Server.Logic/Api/Hubs/MashStepsHub.cs
+++ b/Server/Brewery.Server.Logic/Api/Hubs/MashStepsHub.cs
@@ -1,0 +1,78 @@
+using Brewery.Core;
+using Brewery.Server.Core.Models;
+using Brewery.Server.Core.Service;
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Brewery.Server.Logic.Api.Hubs
+{
+    public class MashStepsHub : Microsoft.AspNetCore.SignalR.Hub
+    {
+        private MashSteps _mashSteps { get; }
+        private IBoilingPlate1Worker _boilingPlate1Worker { get; }
+
+        public MashStepsHub()
+        {
+            _mashSteps = IocContainer.GetInstance<MashSteps>();
+            _boilingPlate1Worker = IocContainer.GetInstance<IBoilingPlate1Worker>();
+        }
+
+        // Client can call these methods
+        public async Task<MashStep[]> GetMashSteps()
+        {
+            return await Task.FromResult(_mashSteps.ToArray());
+        }
+
+        public async Task<MashStep> GetCurrentMashStep()
+        {
+            return await Task.FromResult(_boilingPlate1Worker.GetCurrentStep());
+        }
+
+        public async Task<int> GetTotalEstimatedRemainingTime()
+        {
+            return await Task.FromResult(_mashSteps.Sum(ms => ms.EstimatedTime));
+        }
+
+        public async Task UpdateMashStep(MashStep mashStep)
+        {
+            var index = _mashSteps.IndexOf(_mashSteps.First(ms => ms.Guid == mashStep.Guid));
+            _mashSteps[index] = mashStep;
+            await Clients.All.SendAsync("MashStepUpdated", mashStep);
+            await Clients.All.SendAsync("MashStepsChanged");
+        }
+
+        public async Task DeleteMashStep(string guid)
+        {
+            _mashSteps.Remove(_mashSteps.First(ms => ms.Guid == guid));
+            await Clients.All.SendAsync("MashStepDeleted", guid);
+            await Clients.All.SendAsync("MashStepsChanged");
+        }
+
+        public async Task<MashStep> InsertMashStep(MashStep mashStep)
+        {
+            mashStep.Guid = Guid.NewGuid().ToString();
+            _mashSteps.Add(mashStep);
+            await Clients.All.SendAsync("MashStepInserted", mashStep);
+            await Clients.All.SendAsync("MashStepsChanged");
+            return mashStep;
+        }
+
+        // Server calls these methods to push updates to clients
+        public static async Task BroadcastCurrentStep(IHubContext<MashStepsHub> hubContext, MashStep currentStep)
+        {
+            await hubContext.Clients.All.SendAsync("CurrentStepUpdated", currentStep);
+        }
+
+        public static async Task BroadcastTotalEstimatedRemainingTime(IHubContext<MashStepsHub> hubContext, int totalTime)
+        {
+            await hubContext.Clients.All.SendAsync("TotalEstimatedRemainingTimeUpdated", totalTime);
+        }
+
+        public static async Task BroadcastMashStepsChanged(IHubContext<MashStepsHub> hubContext)
+        {
+            await hubContext.Clients.All.SendAsync("MashStepsChanged");
+        }
+    }
+}

--- a/Server/Brewery.Server.Logic/Server.cs
+++ b/Server/Brewery.Server.Logic/Server.cs
@@ -2,6 +2,7 @@ using Brewery.Server.Core;
 using Brewery.Server.Core.Service;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -33,17 +34,27 @@ namespace Brewery.Server.Logic
             // Configure services
             builder.Services.AddControllers()
                 .AddApplicationPart(typeof(Server).Assembly);
+
+            // Add SignalR
+            builder.Services.AddSignalR();
+
             builder.Services.AddCors(options =>
             {
                 options.AddDefaultPolicy(policy =>
                 {
-                    policy.AllowAnyOrigin()
+                    policy.SetIsOriginAllowed(_ => true)
                           .AllowAnyMethod()
-                          .AllowAnyHeader();
+                          .AllowAnyHeader()
+                          .AllowCredentials();
                 });
             });
 
             var app = builder.Build();
+
+            // Initialize hub context provider for workers
+            Api.Hubs.HubContextProvider.BoilingPlate1HubContext = app.Services.GetRequiredService<IHubContext<Api.Hubs.BoilingPlate1Hub>>();
+            Api.Hubs.HubContextProvider.BoilingPlate2HubContext = app.Services.GetRequiredService<IHubContext<Api.Hubs.BoilingPlate2Hub>>();
+            Api.Hubs.HubContextProvider.MashStepsHubContext = app.Services.GetRequiredService<IHubContext<Api.Hubs.MashStepsHub>>();
 
             // Configure middleware
             app.UseCors();
@@ -64,6 +75,11 @@ namespace Brewery.Server.Logic
             });
 
             app.MapControllers();
+
+            // Map SignalR hubs
+            app.MapHub<Api.Hubs.BoilingPlate1Hub>("/hubs/boilingPlate1");
+            app.MapHub<Api.Hubs.BoilingPlate2Hub>("/hubs/boilingPlate2");
+            app.MapHub<Api.Hubs.MashStepsHub>("/hubs/mashSteps");
 
             // Start workers
             _ = Task.Run(() => StartBoilingPlate1WorkerAsync());

--- a/Server/Brewery.Server.Logic/Service/BoilingPlate1Worker.cs
+++ b/Server/Brewery.Server.Logic/Service/BoilingPlate1Worker.cs
@@ -1,8 +1,10 @@
 ﻿using Brewery.Core.Contracts.ServiceAdapter;
 using Brewery.Server.Core.Api;
 using Brewery.Server.Core.Models;
+using Brewery.Server.Logic.Api.Hubs;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Brewery.Server.Logic.Service
@@ -161,6 +163,23 @@ namespace Brewery.Server.Logic.Service
                         {
                             SetNextStep();
                         }
+                    }
+                }
+
+                // Broadcast updates via SignalR
+                var hubContext = HubContextProvider.BoilingPlate1HubContext;
+                if (hubContext != null)
+                {
+                    await BoilingPlate1Hub.BroadcastPowerStatus(hubContext, GetPowerStatus());
+                    await BoilingPlate1Hub.BroadcastCurrentTemperature(hubContext, currentTemperature);
+                    await BoilingPlate1Hub.BroadcastCurrentStep(hubContext, currentStep.Step, currentStep.EstimatedTime);
+
+                    // Also broadcast mash steps updates
+                    var mashStepsHubContext = HubContextProvider.MashStepsHubContext;
+                    if (mashStepsHubContext != null)
+                    {
+                        await MashStepsHub.BroadcastCurrentStep(mashStepsHubContext, currentStep);
+                        await MashStepsHub.BroadcastTotalEstimatedRemainingTime(mashStepsHubContext, _brewProcessSteps.Sum(ms => ms.EstimatedTime));
                     }
                 }
             }

--- a/Server/Brewery.Server.Logic/Service/BoilingPlate2Worker.cs
+++ b/Server/Brewery.Server.Logic/Service/BoilingPlate2Worker.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Brewery.Core.Contracts.ServiceAdapter;
 using Brewery.Server.Core.Api;
 using Brewery.Server.Core.Models;
+using Brewery.Server.Logic.Api.Hubs;
 
 namespace Brewery.Server.Logic.Service
 {
@@ -40,12 +41,21 @@ namespace Brewery.Server.Logic.Service
                 {
                     _gpioModule.Power(Settings.BoilingPlate2Gpio.GpioNumber, false);
                 }
+
+                // Broadcast updates via SignalR
+                var hubContext = HubContextProvider.BoilingPlate2HubContext;
+                if (hubContext != null)
+                {
+                    await BoilingPlate2Hub.BroadcastPowerStatus(hubContext, _boilingPlate2Model.PowerStatus);
+                    await BoilingPlate2Hub.BroadcastCurrentTemperature(hubContext, temperatureCurrent);
+                    await BoilingPlate2Hub.BroadcastTemperatureSetpoint(hubContext, _boilingPlate2Model.Temperature);
+                }
             }
             catch (System.Exception ex)
             {
                 Debug.WriteLine(ex.ToString());
             }
-            
+
         }
     }
 }


### PR DESCRIPTION
Fixed compilation errors by renaming the Hub namespace from 'Brewery.Server.Logic.Api.Hub' to 'Brewery.Server.Logic.Api.Hubs' to prevent conflict with Microsoft.AspNetCore.SignalR.Hub base class.

Changes:
- Created SignalR Hub classes (BoilingPlate1Hub, BoilingPlate2Hub, MashStepsHub)
- Added HubContextProvider for managing hub contexts
- Configured SignalR in Server.cs with proper CORS settings
- Added SignalR broadcasting to worker services
- Used fully qualified Hub base class name to avoid ambiguity

This resolves the 10 compilation errors related to Hub type constraints and namespace conflicts reported in issue #85.