### PR TITLE
Fix empty table issue in mash steps settings

### DIFF
--- a/WebApp/src/app/mash-steps/mash-steps.component.ts
+++ b/WebApp/src/app/mash-steps/mash-steps.component.ts
@@ -21,8 +21,24 @@ export class MashStepsComponent implements OnInit {
 
   columnDefs = [
     { headerName: 'Schritt', field: 'Step', editable: true, checkboxSelection: true },
-    { headerName: 'Rührwerk', field: 'Mixer', editable: true, cellEditor: 'select', cellEditorParams: this.trueFalseCellEditorParams },
-    { headerName: 'Alarm', field: 'Alert', editable: true, cellEditor: 'select', cellEditorParams: this.trueFalseCellEditorParams },
+    {
+      headerName: 'Rührwerk',
+      field: 'Mixer',
+      editable: true,
+      cellEditor: 'agSelectCellEditor',
+      cellEditorParams: { values: this.trueFalseValues },
+      valueFormatter: (params) => params.value ? 'true' : 'false',
+      valueParser: (params) => params.newValue === 'true'
+    },
+    {
+      headerName: 'Alarm',
+      field: 'Alert',
+      editable: true,
+      cellEditor: 'agSelectCellEditor',
+      cellEditorParams: { values: this.trueFalseValues },
+      valueFormatter: (params) => params.value ? 'true' : 'false',
+      valueParser: (params) => params.newValue === 'true'
+    },
     { headerName: 'Temperatur', field: 'Temperature', editable: true, valueParser: 'Number(newValue)' },
     { headerName: 'Rast', field: 'Rast', editable: true, valueParser: 'Number(newValue)' }
   ];


### PR DESCRIPTION
Updated ag-grid column definitions to use correct cell editor:
- Changed 'select' to 'agSelectCellEditor' for Mixer and Alert fields
- Added valueFormatter to display boolean values as strings
- Added valueParser to convert edited string values back to booleans

This fixes issue #87 where the table appeared empty despite data being received from the backend. The invalid cell editor name 'select' was preventing ag-grid from rendering the cells properly.

Fix #87 