### PR TITLE
Fix field name casing mismatch between API and frontend

### DIFF
--- a/WebApp/src/app/boiling-plate1/boiling-plate1.component.ts
+++ b/WebApp/src/app/boiling-plate1/boiling-plate1.component.ts
@@ -38,8 +38,8 @@ export class BoilingPlate1Component implements OnInit, OnDestroy {
         )
       )
       .subscribe(mashStep => {
-        this.CurrentStepName = mashStep.Step;
-        this.CurrentStepEstimatedRemainingTime = mashStep.EstimatedTime;
+        this.CurrentStepName = mashStep.step;
+        this.CurrentStepEstimatedRemainingTime = mashStep.estimatedTime;
       });
 
     // this.getTotalEstimatedRemainingTime();
@@ -91,9 +91,9 @@ export class BoilingPlate1Component implements OnInit, OnDestroy {
   // getCurrentStep(): void {
   //   this.mashStepsService.getCurrentMashStep()
   //     .subscribe(mashStep => {
-  //       this.CurrentStepName = mashStep.Step;
-  //       const elapsedTime = mashStep.ElapsedMinutes === undefined ? mashStep.Rast : mashStep.ElapsedMinutes;
-  //       this.CurrentStepEstimatedRemainingTime = mashStep.Rast - elapsedTime;
+  //       this.CurrentStepName = mashStep.step;
+  //       const elapsedTime = mashStep.ElapsedMinutes === undefined ? mashStep.rast : mashStep.ElapsedMinutes;
+  //       this.CurrentStepEstimatedRemainingTime = mashStep.rast - elapsedTime;
   //     });
   // }
 

--- a/WebApp/src/app/mash-steps/mash-steps.component.ts
+++ b/WebApp/src/app/mash-steps/mash-steps.component.ts
@@ -20,10 +20,10 @@ export class MashStepsComponent implements OnInit {
   trueFalseCellEditorParams = { values: this.trueFalseValues };
 
   columnDefs = [
-    { headerName: 'Schritt', field: 'Step', editable: true, checkboxSelection: true },
+    { headerName: 'Schritt', field: 'step', editable: true, checkboxSelection: true },
     {
       headerName: 'Rührwerk',
-      field: 'Mixer',
+      field: 'mixer',
       editable: true,
       cellEditor: 'agSelectCellEditor',
       cellEditorParams: { values: this.trueFalseValues },
@@ -32,15 +32,15 @@ export class MashStepsComponent implements OnInit {
     },
     {
       headerName: 'Alarm',
-      field: 'Alert',
+      field: 'alert',
       editable: true,
       cellEditor: 'agSelectCellEditor',
       cellEditorParams: { values: this.trueFalseValues },
       valueFormatter: (params) => params.value ? 'true' : 'false',
       valueParser: (params) => params.newValue === 'true'
     },
-    { headerName: 'Temperatur', field: 'Temperature', editable: true, valueParser: 'Number(newValue)' },
-    { headerName: 'Rast', field: 'Rast', editable: true, valueParser: 'Number(newValue)' }
+    { headerName: 'Temperatur', field: 'temperature', editable: true, valueParser: 'Number(newValue)' },
+    { headerName: 'Rast', field: 'rast', editable: true, valueParser: 'Number(newValue)' }
   ];
 
   constructor(private mashStepsService: MashStepsService) { }
@@ -92,9 +92,9 @@ export class MashStepsComponent implements OnInit {
 
   addNewMashStep() {
     const newMashStep = new MashStep();
-    newMashStep.Step = 'new step';
-    newMashStep.Active = false;
-    newMashStep.Rast = 60;
+    newMashStep.step = 'new step';
+    newMashStep.active = false;
+    newMashStep.rast = 60;
     this.mashStepsService.addMashStep(newMashStep).subscribe(r => this.getMashSteps());
   }
 }

--- a/WebApp/src/app/mashStep.ts
+++ b/WebApp/src/app/mashStep.ts
@@ -1,11 +1,11 @@
 export class MashStep {
-    Step: string;
-    Active: boolean;
-    Elapsed: number;
-    Alert: boolean;
-    Mixer: boolean;
-    Rast: number;
-    Temperature: number;
-    Guid: string;
-    EstimatedTime: number;
+    step: string;
+    active: boolean;
+    elapsed: number;
+    alert: boolean;
+    mixer: boolean;
+    rast: number;
+    temperature: number;
+    guid: string;
+    estimatedTime: number;
 }


### PR DESCRIPTION
The API returns field names in camelCase (step, temperature, rast, etc.) but the TypeScript model and column definitions were using PascalCase (Step, Temperature, Rast, etc.), causing ag-grid to not display the data.

Changes:
- Updated MashStep model to use camelCase properties
- Updated column definitions in mash-steps component to use camelCase field names
- Updated property references in boiling-plate1 component to use camelCase

This fixes issue #87 where the table showed empty rows despite receiving valid data from the backend. The root cause was the field name mismatch preventing ag-grid from binding the data to the columns.