### PR TITLE
Fix delete button not activating on checkbox selection

### DIFF
--- a/WebApp/src/app/mash-steps/mash-steps.component.html
+++ b/WebApp/src/app/mash-steps/mash-steps.component.html
@@ -1,8 +1,9 @@
 <ag-grid-angular id="api" style="width: 100%; height: 250px" class="ag-theme-balham" suppressRowClickSelection
-    (gridReady)="onGridReady($event)" (cellValueChanged)="onCellValueChanged($event)" [rowData]="mashSteps"
+    (gridReady)="onGridReady($event)" (cellValueChanged)="onCellValueChanged($event)"
+    (selectionChanged)="onSelectionChanged()" [rowData]="mashSteps"
     [columnDefs]="columnDefs" rowSelection="multiple">
 </ag-grid-angular>
-<button mat-button (click)="deleteSelectedRows()" [disabled]="!rowsSelected()">
+<button mat-button (click)="deleteSelectedRows()" [disabled]="!hasSelectedRows">
     Schritt(e) löschen
 </button>
 <button mat-button (click)="addNewMashStep()">

--- a/WebApp/src/app/mash-steps/mash-steps.component.ts
+++ b/WebApp/src/app/mash-steps/mash-steps.component.ts
@@ -16,6 +16,7 @@ export class MashStepsComponent implements OnInit {
   private columnApi;
 
   mashSteps: MashStep[] = [];
+  hasSelectedRows = false;
   trueFalseValues: string[] = ['true', 'false'];
   trueFalseCellEditorParams = { values: this.trueFalseValues };
 
@@ -55,6 +56,10 @@ export class MashStepsComponent implements OnInit {
     this.columnApi = params.columnApi;
 
     this.api.sizeColumnsToFit();
+  }
+
+  onSelectionChanged(): void {
+    this.hasSelectedRows = this.api && this.api.getSelectedRows().length > 0;
   }
 
   rowsSelected() {


### PR DESCRIPTION
Added selectionChanged event handler to update button state when rows are selected/deselected in the ag-grid table.

Changes:
- Added hasSelectedRows property to track selection state
- Added onSelectionChanged() method to update state
- Bound (selectionChanged) event in template
- Changed button [disabled] binding to use hasSelectedRows

This ensures Angular's change detection is triggered when checkboxes are selected, allowing the delete button to be enabled/disabled correctly.