### PR TITLE
Replace boolean dropdowns with checkboxes for Mixer and Alert

### DIFF
--- a/WebApp/src/app/mash-steps/mash-steps.component.ts
+++ b/WebApp/src/app/mash-steps/mash-steps.component.ts
@@ -17,8 +17,6 @@ export class MashStepsComponent implements OnInit {
 
   mashSteps: MashStep[] = [];
   hasSelectedRows = false;
-  trueFalseValues: string[] = ['true', 'false'];
-  trueFalseCellEditorParams = { values: this.trueFalseValues };
 
   columnDefs = [
     { headerName: 'Schritt', field: 'step', editable: true, checkboxSelection: true },
@@ -26,19 +24,15 @@ export class MashStepsComponent implements OnInit {
       headerName: 'Rührwerk',
       field: 'mixer',
       editable: true,
-      cellEditor: 'agSelectCellEditor',
-      cellEditorParams: { values: this.trueFalseValues },
-      valueFormatter: (params) => params.value ? 'true' : 'false',
-      valueParser: (params) => params.newValue === 'true'
+      cellRenderer: 'agCheckboxCellRenderer',
+      cellEditor: 'agCheckboxCellEditor'
     },
     {
       headerName: 'Alarm',
       field: 'alert',
       editable: true,
-      cellEditor: 'agSelectCellEditor',
-      cellEditorParams: { values: this.trueFalseValues },
-      valueFormatter: (params) => params.value ? 'true' : 'false',
-      valueParser: (params) => params.newValue === 'true'
+      cellRenderer: 'agCheckboxCellRenderer',
+      cellEditor: 'agCheckboxCellEditor'
     },
     { headerName: 'Temperatur', field: 'temperature', editable: true, valueParser: 'Number(newValue)' },
     { headerName: 'Rast', field: 'rast', editable: true, valueParser: 'Number(newValue)' }


### PR DESCRIPTION
Changed Rührwerk (mixer) and Alarm (alert) fields from dropdown selectors to checkboxes, which is more appropriate for boolean values.

Changes:
- Removed trueFalseValues array and complex valueFormatter/valueParser
- Replaced agSelectCellEditor with agCheckboxCellEditor
- Added agCheckboxCellRenderer for proper display
- Checkboxes can be toggled directly without dropdown selection

This fixes the issue where both dropdown options showed as "true" and changes were not properly saved.