### PR TITLE
Fix temperature slider not working in BoilingPlate2

### DIFF
--- a/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
+++ b/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
@@ -2,7 +2,7 @@
   Steuerung: <mat-slide-toggle [(ngModel)]="Power" (change)="onPowerToggleChange($event)"></mat-slide-toggle>
 </p>
 <p>
-  Temperatur soll: <mat-slider (input)="onTemperatureSliderChange($event)" (change)="onTemperatureSliderChangeEnd($event)" thumbLabel="true" [(ngModel)]="Temperature"></mat-slider> {{Temperature}} &deg;C
+  Temperatur soll: <mat-slider min="0" max="100" step="1" (input)="onTemperatureSliderChange($event)" (change)="onTemperatureSliderChangeEnd($event)" thumbLabel="true" [(ngModel)]="Temperature"></mat-slider> {{Temperature}} &deg;C
 </p>
 <p>
   Temperatur aktuell: {{TemperatureCurrent}} &deg;C


### PR DESCRIPTION
Added missing min, max, and step attributes to the mat-slider component. Without these required attributes, the slider was non-functional and could not be moved or adjusted. The slider now has a range of 0-100°C with 1°C increments, which is appropriate for brewing temperature control.

Fixes #88