### PR TITLE
Update temperature slider to Angular Material v19 API

### DIFF
--- a/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
+++ b/WebApp/src/app/boiling-plate2/boiling-plate2.component.html
@@ -2,7 +2,9 @@
   Steuerung: <mat-slide-toggle [(ngModel)]="Power" (change)="onPowerToggleChange($event)"></mat-slide-toggle>
 </p>
 <p>
-  Temperatur soll: <mat-slider min="0" max="100" step="1" (input)="onTemperatureSliderChange($event)" (change)="onTemperatureSliderChangeEnd($event)" thumbLabel="true" [(ngModel)]="Temperature"></mat-slider> {{Temperature}} &deg;C
+  Temperatur soll: <mat-slider min="0" max="100" step="1">
+    <input matSliderThumb (dragStart)="onTemperatureSliderChange($event)" (dragEnd)="onTemperatureSliderChangeEnd($event)" [(ngModel)]="Temperature">
+  </mat-slider> {{Temperature}} &deg;C
 </p>
 <p>
   Temperatur aktuell: {{TemperatureCurrent}} &deg;C

--- a/WebApp/src/app/boiling-plate2/boiling-plate2.component.ts
+++ b/WebApp/src/app/boiling-plate2/boiling-plate2.component.ts
@@ -76,11 +76,12 @@ export class BoilingPlate2Component implements OnInit, OnDestroy {
 
   onTemperatureSliderChange(event) {
     this.isUserChangingTemperature = true;
-    this.Temperature = event.value;
+    // For dragStart event, the value is already in this.Temperature due to ngModel binding
   }
 
   onTemperatureSliderChangeEnd(event) {
-    this.boilingPlate2Service.setTemperature(event.value).subscribe(() => {
+    // For dragEnd event, the value is already in this.Temperature due to ngModel binding
+    this.boilingPlate2Service.setTemperature(this.Temperature).subscribe(() => {
       this.isUserChangingTemperature = false;
     });
   }


### PR DESCRIPTION
Migrated the mat-slider component to the new Angular Material v19 API:
- Added required <input matSliderThumb> element inside mat-slider
- Changed event bindings from (input)/(change) to (dragStart)/(dragEnd)
- Updated event handlers to work with new API and ngModel binding
- The slider now properly responds to user interaction

The old API (input/change events) was deprecated and not working in v19. The new API requires matSliderThumb directive for proper event handling.

Fixes #88